### PR TITLE
Remove arguments overload in surface_SetDrawColor

### DIFF
--- a/src/rndx.lua
+++ b/src/rndx.lua
@@ -211,7 +211,7 @@ local function draw_rounded(x, y, w, h, col, flags, tl, tr, bl, br, texture, thi
 	SetMatFloat(mat, C_POWER_PARAM, shape_value or 2.2)
 
 	if col then
-		surface_SetDrawColor(col)
+		surface_SetDrawColor(col.r, col.g, col.b, col.a)
 	else
 		surface_SetDrawColor(255, 255, 255, 255)
 	end
@@ -355,7 +355,7 @@ function RNDX.DrawShadowsEx(x, y, w, h, col, flags, tl, tr, bl, br, spread, inte
 	end
 
 	if col then
-		surface_SetDrawColor(col)
+		surface_SetDrawColor(col.r, col.g, col.b, col.a)
 	else
 		surface_SetDrawColor(0, 0, 0, 255)
 	end


### PR DESCRIPTION
This is approximately 3 times faster than setting the color with an object
```lua
local color = Color(255, 255, 255, 255)
local surface_SetDrawColor = surface.SetDrawColor

GMODBenchmark(10000000,
function()
    surface_SetDrawColor(color.r, color.g, color.b, color.a)
end,
function()
    surface_SetDrawColor(color)
end)
```

```
Benchmark result (CLIENT):
1: Total: 0.75768480000001, AVG: 7.5768480000001e-08
2: Total: 2.3971835, AVG: 2.3971835e-07
```