### PR TITLE
Allow setting colors not via color objects

### DIFF
--- a/src/rndx.lua
+++ b/src/rndx.lua
@@ -372,7 +372,7 @@ function RNDX.DrawShadowsEx(x, y, w, h, col, flags, tl, tr, bl, br, spread, inte
 		if col then
 			surface_SetDrawColor(col.r, col.g, col.b, col.a)
 		else
-			surface_SetDrawColor(255, 255, 255, 255)
+			surface_SetDrawColor(0, 0, 0, 255)
 		end
 	end
 

--- a/src/rndx.lua
+++ b/src/rndx.lua
@@ -188,7 +188,7 @@ local function SetParams(
 	MATERIAL_SetMatrix(mat, "$viewprojmat", matrix)
 end
 
-local MANUALCOLOR = NEW_FLAG()
+local MANUAL_COLOR = NEW_FLAG()
 local DEFAULT_DRAW_FLAGS = SHAPE_FIGMA
 
 local function draw_rounded(x, y, w, h, col, flags, tl, tr, bl, br, texture, thickness)
@@ -225,7 +225,7 @@ local function draw_rounded(x, y, w, h, col, flags, tl, tr, bl, br, texture, thi
 		0
 	)
 
-	if bit_band(flags, MANUALCOLOR) == 0 then
+	if bit_band(flags, MANUAL_COLOR) == 0 then
 		if col then
 			surface_SetDrawColor(col.r, col.g, col.b, col.a)
 		else
@@ -368,7 +368,7 @@ function RNDX.DrawShadowsEx(x, y, w, h, col, flags, tl, tr, bl, br, spread, inte
 		USE_SHADOWS_BLUR = false
 	end
 
-	if bit_band(flags, MANUALCOLOR) == 0 then
+	if bit_band(flags, MANUAL_COLOR) == 0 then
 		if col then
 			surface_SetDrawColor(col.r, col.g, col.b, col.a)
 		else
@@ -399,7 +399,7 @@ RNDX.SHAPE_FIGMA = SHAPE_FIGMA
 RNDX.SHAPE_IOS = SHAPE_IOS
 
 RNDX.BLUR = BLUR
-RNDX.MANUALCOLOR = MANUALCOLOR
+RNDX.MANUAL_COLOR = MANUAL_COLOR
 
 function RNDX.SetFlag(flags, flag, bool)
 	flag = RNDX[flag] or flag

--- a/src/rndx.lua
+++ b/src/rndx.lua
@@ -224,8 +224,10 @@ local function draw_rounded(x, y, w, h, col, flags, tl, tr, bl, br, texture, thi
 		0
 	)
 
-	if col then
-		surface_SetDrawColor(col.r, col.g, col.b, col.a)
+	if col ~= nil then
+		if col ~= false then
+			surface_SetDrawColor(col.r, col.g, col.b, col.a)
+		end
 	else
 		surface_SetDrawColor(255, 255, 255, 255)
 	end
@@ -364,10 +366,12 @@ function RNDX.DrawShadowsEx(x, y, w, h, col, flags, tl, tr, bl, br, spread, inte
 		USE_SHADOWS_BLUR = false
 	end
 
-	if col then
-		surface_SetDrawColor(col.r, col.g, col.b, col.a)
+	if col ~= nil then
+		if col ~= false then
+			surface_SetDrawColor(col.r, col.g, col.b, col.a)
+		end
 	else
-		surface_SetDrawColor(0, 0, 0, 255)
+		surface_SetDrawColor(255, 255, 255, 255)
 	end
 	surface_SetMaterial(mat)
 	-- https://github.com/Jaffies/rboxes/blob/main/rboxes.lua

--- a/src/rndx.lua
+++ b/src/rndx.lua
@@ -188,6 +188,7 @@ local function SetParams(
 	MATERIAL_SetMatrix(mat, "$viewprojmat", matrix)
 end
 
+local MANUALCOLOR = NEW_FLAG()
 local DEFAULT_DRAW_FLAGS = SHAPE_FIGMA
 
 local function draw_rounded(x, y, w, h, col, flags, tl, tr, bl, br, texture, thickness)
@@ -224,13 +225,14 @@ local function draw_rounded(x, y, w, h, col, flags, tl, tr, bl, br, texture, thi
 		0
 	)
 
-	if col ~= nil then
-		if col ~= false then
+	if bit_band(flags, MANUALCOLOR) == 0 then
+		if col then
 			surface_SetDrawColor(col.r, col.g, col.b, col.a)
+		else
+			surface_SetDrawColor(255, 255, 255, 255)
 		end
-	else
-		surface_SetDrawColor(255, 255, 255, 255)
 	end
+
 	surface_SetMaterial(mat)
 	-- https://github.com/Jaffies/rboxes/blob/main/rboxes.lua
 	-- fixes setting $basetexture to ""(none) not working correctly
@@ -366,13 +368,14 @@ function RNDX.DrawShadowsEx(x, y, w, h, col, flags, tl, tr, bl, br, spread, inte
 		USE_SHADOWS_BLUR = false
 	end
 
-	if col ~= nil then
-		if col ~= false then
+	if bit_band(flags, MANUALCOLOR) == 0 then
+		if col then
 			surface_SetDrawColor(col.r, col.g, col.b, col.a)
+		else
+			surface_SetDrawColor(255, 255, 255, 255)
 		end
-	else
-		surface_SetDrawColor(0, 0, 0, 255)
 	end
+
 	surface_SetMaterial(mat)
 	-- https://github.com/Jaffies/rboxes/blob/main/rboxes.lua
 	-- fixes having no $basetexture causing uv to be broken
@@ -396,6 +399,7 @@ RNDX.SHAPE_FIGMA = SHAPE_FIGMA
 RNDX.SHAPE_IOS = SHAPE_IOS
 
 RNDX.BLUR = BLUR
+RNDX.MANUALCOLOR = MANUALCOLOR
 
 function RNDX.SetFlag(flags, flag, bool)
 	flag = RNDX[flag] or flag

--- a/src/rndx.lua
+++ b/src/rndx.lua
@@ -371,7 +371,7 @@ function RNDX.DrawShadowsEx(x, y, w, h, col, flags, tl, tr, bl, br, spread, inte
 			surface_SetDrawColor(col.r, col.g, col.b, col.a)
 		end
 	else
-		surface_SetDrawColor(255, 255, 255, 255)
+		surface_SetDrawColor(0, 0, 0, 255)
 	end
 	surface_SetMaterial(mat)
 	-- https://github.com/Jaffies/rboxes/blob/main/rboxes.lua


### PR DESCRIPTION
Sometimes using color objects can be problematic due to performance issues, so this PR allows setting the color via `surface.SetDrawColor` yourself if `col` is `false`