### PR TITLE
Adding functionality to the new interaction interface

### DIFF
--- a/src/rndx.lua
+++ b/src/rndx.lua
@@ -404,6 +404,15 @@ function RNDX.DrawShadowsOutlined(r, x, y, w, h, col, thickness, spread, intensi
 	return RNDX.DrawShadowsEx(x, y, w, h, col, flags, r, r, r, r, spread, intensity, thickness or 1)
 end
 
+function RNDX.DrawShadowsClip(pnl, r, x, y, w, h, col, spread, intensity, flags)
+    local sx, sy = pnl:LocalToScreen(0, 0)
+    local sw, sh = pnl:GetWide(), pnl:GetTall()
+
+    render.SetScissorRect(sx, sy, sx + sw, sy + sh, true)
+    	RNDX.DrawShadowsEx(x, y, w, h, col, flags, r, r, r, r, spread, intensity)
+    render.SetScissorRect(0, 0, 0, 0, false)
+end
+
 local BASE_FUNCS = {
 	Rad = function(self, rad)
 		TL, TR, BL, BR = rad, rad, rad, rad

--- a/src/rndx.lua
+++ b/src/rndx.lua
@@ -500,7 +500,7 @@ local RECT = {
 		if CLIP_PANEL then
 			local sx, sy = CLIP_PANEL:LocalToScreen(0,0)
 			local sw, sh = CLIP_PANEL:GetWide(), CLIP_PANEL:GetTall()
-			render.SetScissorRect(sx, sy, sx+sw, sy+sh, true)
+			render.SetScissorRect(sx, sy, sx + sw, sy + sh, true)
 			old_clip = true
 		end
 

--- a/src/rndx.lua
+++ b/src/rndx.lua
@@ -178,6 +178,9 @@ local COL_R, COL_G, COL_B, COL_A
 local SHAPE, OUTLINE_THICKNESS, AA
 local START_ANGLE, END_ANGLE, ROTATION
 local CLIP_PANEL = nil
+local SHADOW_ENABLED = false
+local SHADOW_SPREAD = 0
+local SHADOW_INTENSITY = 0
 local function RESET_PARAMS()
 	MAT = nil
 	X, Y, W, H = 0, 0, 0, 0
@@ -188,6 +191,9 @@ local function RESET_PARAMS()
 	SHAPE, OUTLINE_THICKNESS, AA = SHAPES[DEFAULT_SHAPE], -1, 0
 	START_ANGLE, END_ANGLE, ROTATION = 0, 360, 0
 	CLIP_PANEL = nil
+	SHADOW_ENABLED = false
+	SHADOW_SPREAD = 0
+	SHADOW_INTENSITY = 0
 end
 
 local function SetupDraw()
@@ -462,6 +468,12 @@ local BASE_FUNCS = {
 		END_ANGLE = angle or 360
 		return self
 	end,
+	Shadow = function(self, spread, intensity)
+		SHADOW_ENABLED = true
+		SHADOW_SPREAD = spread or 30
+		SHADOW_INTENSITY = intensity or (spread or 30) * 1.2
+		return self
+	end,
 	Clip = function(self, pnl)
 		CLIP_PANEL = pnl
 		return self
@@ -481,6 +493,7 @@ local RECT = {
 	StartAngle = BASE_FUNCS.StartAngle,
 	EndAngle = BASE_FUNCS.EndAngle,
 	Clip = BASE_FUNCS.Clip,
+	Shadow = BASE_FUNCS.Shadow,
 
 	Draw = function(self)
 		local old_clip
@@ -489,6 +502,14 @@ local RECT = {
 			local sw, sh = CLIP_PANEL:GetWide(), CLIP_PANEL:GetTall()
 			render.SetScissorRect(sx, sy, sx+sw, sy+sh, true)
 			old_clip = true
+		end
+
+		if SHADOW_ENABLED then
+			RNDX.DrawShadowsEx(X, Y, W, H, Color(COL_R, COL_G, COL_B, COL_A), 0, TL, TR, BL, BR, SHADOW_SPREAD, SHADOW_INTENSITY, OUTLINE_THICKNESS)
+			if old_clip then
+                render.SetScissorRect(0, 0, 0, 0, false)
+            end
+            return
 		end
 
 		if USING_BLUR then

--- a/src/rndx.lua
+++ b/src/rndx.lua
@@ -376,6 +376,8 @@ function RNDX.DrawShadowsEx(x, y, w, h, col, flags, tl, tr, bl, br, spread, inte
 		return
 	end
 
+	local OLD_CLIPPING_STATE = DisableClipping(true)
+
 	RESET_PARAMS()
 
 	if not flags then
@@ -407,6 +409,8 @@ function RNDX.DrawShadowsEx(x, y, w, h, col, flags, tl, tr, bl, br, spread, inte
 	else
 		draw_shadows(0, 0, 0, 255)
 	end
+
+	DisableClipping(OLD_CLIPPING_STATE)
 end
 
 function RNDX.DrawShadows(r, x, y, w, h, col, spread, intensity, flags)
@@ -500,9 +504,12 @@ local RECT = {
 
 	Draw = function(self)
 		local OLD_CLIPPING_STATE
-		if CLIP_PANEL then
+		if SHADOW_ENABLED or CLIP_PANEL then
 			-- if we are inside a panel, we need to draw outside of it
 			OLD_CLIPPING_STATE = DisableClipping(true)
+		end
+
+		if CLIP_PANEL then
 			local sx, sy = CLIP_PANEL:LocalToScreen(0, 0)
 			local sw, sh = CLIP_PANEL:GetSize()
 			render.SetScissorRect(sx, sy, sx + sw, sy + sh, true)
@@ -525,6 +532,9 @@ local RECT = {
 
 		if CLIP_PANEL then
 			render.SetScissorRect(0, 0, 0, 0, false)
+		end
+
+		if SHADOW_ENABLED or CLIP_PANEL then
 			DisableClipping(OLD_CLIPPING_STATE)
 		end
 	end


### PR DESCRIPTION
## Description
Prevents shadows from overflowing outside your scroll panels (or any container) without manual scissor boilerplate.

## Before / After

<img width="1177" height="626" alt="gmod_7VSSJbBEM1" src="https://github.com/user-attachments/assets/db2b0e79-ff08-41cf-8f19-46b905d39be7" />

## Example from screenshot

```lua
local m = vgui.Create('DFrame')
m:SetSize(500, 300)
m:Center()
m:MakePopup()

local sp = vgui.Create('DScrollPanel', m)
sp:Dock(FILL)

for k = 1, 5 do
    local btn = vgui.Create('DButton', sp)
    btn:Dock(TOP)
    btn:DockMargin(8, 8, 8, 10)
    btn:SetTall(120)
    btn.Paint = function(self, w, h)
        -- RNDX.DrawShadows(6, 0, 0, w, h, Color(0,0,0,120), 4, 8)
        RNDX.DrawShadowsClip(sp, 6, 0, 0, w, h, Color(0,0,0,120), 4, 8)
        RNDX.Draw(6, 0, 0, w, h, Color(100,150,240))
    end
end
```

P.S. there was an idea to let you pass the actual VGUI component being drawn and then recursively search its ancestors for a DScrollPanel (if one exists) and clip against that. However, that’s just a special case - it’s far more useful to give people a dedicated tool that works for any panel, not only scroll panels