### PR TITLE
Added support for usage with stencils.

### DIFF
--- a/src/rndx_rounded_blur_psxx.hlsl
+++ b/src/rndx_rounded_blur_psxx.hlsl
@@ -9,6 +9,10 @@
 float4 main(PS_INPUT i) : COLOR
 {
     float rounded_alpha = calculate_rounded_alpha(i);
+
+	if (rounded_alpha <= 0.0f)
+		discard;
+
     float3 blr = blur(i.pos * Tex1Size, BLUR_VERTICAL);
     return float4(blr, rounded_alpha);
 }

--- a/src/rndx_rounded_psxx.hlsl
+++ b/src/rndx_rounded_psxx.hlsl
@@ -2,6 +2,10 @@
 
 float4 main(PS_INPUT i) : COLOR {
     float alpha = calculate_rounded_alpha(i);
+
+	if (alpha <= 0.0f)
+		discard;
+
     float4 rect_color = USE_TEXTURE == 1 ? tex2D(TexBase, i.uv.xy) * i.color : i.color;
     return float4(rect_color.rgb, rect_color.a * alpha);
 }

--- a/src/rndx_shadows_blur_psxx.hlsl
+++ b/src/rndx_shadows_blur_psxx.hlsl
@@ -9,6 +9,10 @@
 float4 main(PS_INPUT i) : COLOR
 {
     float rounded_alpha = calculate_smooth_rounded_alpha(i);
+
+	if (rounded_alpha <= 0.0f)
+		discard;
+		
     float3 blr = blur(i.pos * Tex1Size, BLUR_VERTICAL);
     return float4(blr, rounded_alpha);
 }

--- a/src/rndx_shadows_psxx.hlsl
+++ b/src/rndx_shadows_psxx.hlsl
@@ -2,6 +2,10 @@
 
 float4 main(PS_INPUT i) : COLOR {
     float alpha = calculate_smooth_rounded_alpha(i);
+
+	if (alpha <= 0.0f)
+		discard;
+		
     float4 rect_color = i.color;
     return float4(rect_color.rgb, rect_color.a * alpha);
 }


### PR DESCRIPTION
As the shader rendered every pixel even when alpha is 0. It pushes a value into the render buffer, meaning stencils will see it as a rectangle. By discarding the fragment pass when alpha is 0, we can now use these as masks within stencils.