### PR TITLE
Added outlined texture and material drawing functions

### DIFF
--- a/src/rndx.lua
+++ b/src/rndx.lua
@@ -311,10 +311,21 @@ function RNDX.DrawTexture(r, x, y, w, h, col, texture, flags)
 	return draw_rounded(x, y, w, h, col, flags, r, r, r, r, texture)
 end
 
+function RNDX.DrawTextureOutlined(r, x, y, w, h, col, texture, thickness, flags)
+	return draw_rounded(x, y, w, h, col, flags, r, r, r, r, texture, thickness or 1)
+end
+
 function RNDX.DrawMaterial(r, x, y, w, h, col, mat, flags)
 	local tex = mat:GetTexture("$basetexture")
 	if tex then
 		return RNDX.DrawTexture(r, x, y, w, h, col, tex, flags)
+	end
+end
+
+function RNDX.DrawMaterialOutlined(r, x, y, w, h, col, mat, thickness, flags)
+	local tex = mat:GetTexture("$basetexture")
+	if tex then
+		return RNDX.DrawTextureOutlined(r, x, y, w, h, col, tex, thickness or 1, flags)
 	end
 end
 


### PR DESCRIPTION
Simple as the title, just a couple of new functions that gives new opportunities.

<img width="430" height="153" alt="image" src="https://github.com/user-attachments/assets/d75f1dc3-a433-46cc-8171-337163069dfe" />
<img width="400" height="136" alt="image" src="https://github.com/user-attachments/assets/b68b642e-4451-4412-a047-327192473800" />

Two new functions:
- RNDX.DrawMaterialOutlined(r, x, y, w, h, col, mat, thickness, flags)
- RNDX.DrawTextureOutlined(r, x, y, w, h, col, texture, thickness, flags)